### PR TITLE
fixed bug setting properties to an other than the desired axis handle

### DIFF
--- a/testing/pltCSYS.m
+++ b/testing/pltCSYS.m
@@ -30,9 +30,10 @@ while true                                      % the parent handle of the line 
 end
 ornt = axH.View;                                % get orientation
 if ~logical(ornt(1))                            % first value is the azimuth
-    set(axH.Parent,'CurrentAxes',axH);          % make target axis current
-    view(3);
-    axis vis3d
+    % selecting the axis using set() doesn't work in this case, thanks
+    % matlab, honestly wtf
+    view(axH,3);
+    axis(axH,'vis3d')
 end
 
 end


### PR DESCRIPTION
removed the set() method for selecting the axis handle we want to modify
instead give the handle directly to the methods