### PR TITLE
Updates to create matrix of column vectors when using rectangleVert

### DIFF
--- a/fun/applytm/applytm.m
+++ b/fun/applytm/applytm.m
@@ -2,6 +2,7 @@ function [vec] = applytm(vec,TM)
 %APPLYTM Apply transformation matrix
 %   Detailed explanation goes here
 
+nrowsvec = size(vec,1);
 sTM = size(TM);
 if ~(sTM(1) == sTM(2))
     error('Transformation dimensions incorrect')
@@ -14,5 +15,11 @@ switch sTM     % determine type of transformation matrix provided
 end
 % apply transformation
 vec = dim4(TM' * dim4(vec,1,'forward'),1,'backward');
+% if the vector matrix was size 2, so x,y information, we converted it to
+% a generix x,y,z vector matrix, with the z-values being 0, but we only
+% want to return an x,y vector matrix again
+if nrowsvec==2
+    vec = vec(1:2,:);
+end
 end
 

--- a/fun/dim4.m
+++ b/fun/dim4.m
@@ -14,9 +14,12 @@ function [A] = dim4(A,type,direction)
 
 switch type
     case 1
-        ncols = size(A,2);      % number of column vectors in the matrix of vectors
+        [nrows,ncols] = size(A);      % number of column vectors in the matrix of vectors
         switch direction
             case 'forward'
+                if nrows==2             % if the vector has two rows, its only x,y, add z-value of value 0
+                    A = [A;zeros(1,ncols)];
+                end
                 A = [A;ones(1,ncols)];
             case 'backward'
                 A = A(1:3,:);

--- a/fun/rectangleVert/rectangleVert.m
+++ b/fun/rectangleVert/rectangleVert.m
@@ -37,11 +37,14 @@ extension = p.Results.extension;
 if isscalar(extension)
     % when the extension we are given is a scalar, the shape of the rectangle
     % vertices returned is square
-    extension(2) = extension;
+    extension(2,1) = extension;
 elseif isvector(extension)
     % when the extensions we are given is a vector, only the use the first
     % two elements, the function is limited to 2d
     extension = extension(1:2);
+    if isrow(extension)          % make sure the extension parameter is a column vector
+        extension = extension';
+    end
 end
 % "parse" coordinate system behaviour
 coordOffs = eye(3);     % transformation matrix
@@ -54,17 +57,18 @@ end
 % "parse" density parameter
 density = p.Results.density + 2;
 
-xvals = linspace(0,extension(1),density)';
-yvals = linspace(0,extension(2),density)';
+
+xvals = linspace(0,extension(1),density);
+yvals = linspace(0,extension(2),density);
 xvals = xvals(1:end-1);
 yvals = yvals(1:end-1);
 density = density -1;
-vertices =[xvals,zeros(density,1);...
-           repmat(extension(1),density,1),yvals;...
-           extension;...
-           flipud(xvals),repmat(extension(2),density,1);...
-           zeros(density,1), flipud(yvals)];
-vert = [vertices,ones(length(vertices),1)] * coordOffs;
+vertices =[[xvals;zeros(1,density)],...
+           [repmat(extension(1),1,density);yvals],...
+           extension,...
+           [fliplr(xvals);repmat(extension(2),1,density)],...
+           [zeros(1,density); fliplr(yvals)]];
+vert = applytm(vertices,coordOffs);
 vertices = vert(:,1:end-1);
 end
 

--- a/fun/rectangleVert/rectangleVerttesting.m
+++ b/fun/rectangleVert/rectangleVerttesting.m
@@ -1,33 +1,33 @@
 figH = getFigH(3);
 
-% square rectangle, simplest form
-vert1 = rectangleVert(1);
-set(0,'CurrentFigure',figH(1));
-plot(polyshape(vert1));
-grid on; grid minor; axis equal;
-
-% square rectangle, coordinate system in the center, no extra vertices
-vert2 = rectangleVert(1,'coordinateSystem','center','density',0);
-% different spelling
-vert3 = rectangleVert(1,'coordinateSystem','centre','density',0);
-% different spelling
-vert3 = rectangleVert(1,'coordinateSystem','c','density',0);
-
-% square rectangle, force coordinate system to lower left
-vert4 = rectangleVert(1,'coordinateSystem','lowerleft','density',0);
-% different spelling
-vert4 = rectangleVert(1,'coordinateSystem','ll','density',0);
-
-% non-square rectangle
-vert5 = rectangleVert([1,2]);
-set(0,'CurrentFigure',figH(2));
-plot(polyshape(vert5))
-grid on; grid minor; axis equal;
+% % square rectangle, simplest form
+% vert1 = rectangleVert(1);
+% set(0,'CurrentFigure',figH(1));
+% plot(polyshape(vert1));
+% grid on; grid minor; axis equal;
+% 
+% % square rectangle, coordinate system in the center, no extra vertices
+% vert2 = rectangleVert(1,'coordinateSystem','center','density',0);
+% % different spelling
+% vert3 = rectangleVert(1,'coordinateSystem','centre','density',0);
+% % different spelling
+% vert3 = rectangleVert(1,'coordinateSystem','c','density',0);
+% 
+% % square rectangle, force coordinate system to lower left
+% vert4 = rectangleVert(1,'coordinateSystem','lowerleft','density',0);
+% % different spelling
+% vert4 = rectangleVert(1,'coordinateSystem','ll','density',0);
+% 
+% % non-square rectangle
+% vert5 = rectangleVert([1,2]);
+% set(0,'CurrentFigure',figH(2));
+% plot(polyshape(vert5))
+% grid on; grid minor; axis equal;
 
 % higher density shapes
 vert6 = rectangleVert([1,2],'coordinateSystem','c','loop','tight','density',9);
 set(0,'CurrentFigure',figH(3));
-plot(polyshape(vert6,'Simplify',false));
+plot(polyshape(vert6','Simplify',false));
 grid on; grid minor; axis equal;
-line(vert6(:,1),vert6(:,2),'LineStyle','none','Marker','.','Color','r')
+line(vert6(1,:),vert6(2,:),'LineStyle','none','Marker','.','Color','r')
 


### PR DESCRIPTION
- fix: return transformed 2xn vector, when 2xn vector is provided
dim4:
- fix: add general z-values to 2xn matrices of vectors, to be able to treat the vectors as 3d
rectangleVert:
- fix: return matrix of colum vectors:
   - convert provided dimensions to colum vector
   - changed creation of vertices to return a matrix of vectors
rectangleVerttesting:
- commented out currently unnesseray tests