### PR TITLE
Update calls after changes in the rectangleVert function

### DIFF
--- a/fun/pltCSYS/pltCSYS.m
+++ b/fun/pltCSYS/pltCSYS.m
@@ -15,7 +15,7 @@ switch norgn                    % act on dimension of origin matrix
     case 1                      % origin information we are given is 1d
         origin = repmat(origin,1,3);
     case 3                      % origin is matrix of vectors
-        if any(origin(:,1:2) == origin(:,2:3),'all')
+        if ~any(origin(:,1:2) == origin(:,2:3),'all')
             % only if all vectors are the same, are the first and last two columns identical
             error('Not all vectors in the matrix are equal.')
         end

--- a/fun/testing/rotation.m
+++ b/fun/testing/rotation.m
@@ -11,8 +11,8 @@ normal = [0,0,1]';                                  % polyshapes default to the 
 origin = zeros(3);                                  % origin-coordinate system as matrix of component vectors
 csys = eye(3);                                      % origin coordinate system as matrix of the vectors
 
-polvert = rectangleVert([2,2],'center',2);          % create polygon vertices
-polyg = polyshape(polvert);                         % create polyshape object
+polvert = rectangleVert([2,2],'coordinateSystem','center','density',2);     % create polygon vertices
+polyg = polyshape(polvert');                         % create polyshape object
 plot(polyg,'Parent',grp)                            % plot shape
 
 basetm = vec2rot(normal,rotaxis);                           % create the base transformation matrix, so object is perpendicular to rotation axis


### PR DESCRIPTION
pltCSYS:
- bug: logic determining the velidity of origin coordinates threw an error when coordinates are valid
rotation:
- feature: call to the rectangleVert is up to date now