### PR TITLE
Improve workpiece surface by rotating odd vertices

### DIFF
--- a/fun/pltSim/plotSimulation.m
+++ b/fun/pltSim/plotSimulation.m
@@ -65,10 +65,12 @@ classdef plotSimulation
             % create 3d axes handles
             obj.ax3dH = axes(obj.figH(2));
             axis(obj.ax3dH, 'vis3d');
+            obj.ax3dH.View = [140 45];
             
             % create cut plot
             obj.cutH = axes(obj.figH(3));
             axis(obj.cutH, 'vis3d');
+            obj.cutH.XLim = [-50 50];
             axSetup();
             
             % trajectory line handles: analytic traj, seek, solution, workpiece limit

--- a/methods/vf1/vf1.m
+++ b/methods/vf1/vf1.m
@@ -35,12 +35,12 @@ A = 0;
 ptNm = numel(phi_WZ);
 ptID = 3;                             % select point for plotting
 zInt = [15 90];         % [zmin zmax]
-zRes = 1e2;             % diskrete Schritte in z-Richtung
-circRes = 1e2;          % anzahl punkte entlang dem Werkstückumfang
+zRes = 1e3;             % diskrete Schritte in z-Richtung
+circRes = 1e3;          % anzahl punkte entlang dem Werkstückumfang
 iterAbbr = 1e-3;        % zulässiger Fehler bei der Iteration
 dB = 0.1*pi;            % schrittweite beim seeken
 logStr = {'no', 'yes'}; % logical string for log outputs
-StopCriterion = 2*pi;
+StopCriterion = pi/3;
 % preallocate variables
 z_soll = linspace(zInt(2),zInt(1),zRes);
 Bsol  = NaN(1,ptNm,zRes);   % Lösungsvektor
@@ -60,6 +60,10 @@ prevEng = false;                        % war Werkzeug beim vorherigen Iteration
 cver = circle(rWst,circRes,[0,0]);      % erzeugen der Vertices der Werkstück-Polygone
 orPgon = polyshape(cver','Simplify',false);              % erzeugen des Originalen Werkstückpolgons
 wkst = repmat(orPgon,zRes,1);
+% rotate the odd numbered polyshapes by half a rotational space
+oddind = logical(mod(1:zRes,2));
+wkst(oddind) = wkst(oddind).rotate( rad2deg( pi/(circRes) ));
+clearvars oddind
 % werkzeug polygon
 [cWZ(1,:),cWZ(2,:)] = pol2cart(phi_WZ,r_WZ,h_WZ);  % kartesische werkzeug koordinaten
 wz = polyshape(cWZ','Simplify',false);
@@ -156,8 +160,9 @@ while runSim
             wz.Vertices = wzV(:,1:2);
             wkst(m) = wkst(m).subtract(wz,'KeepCollinearPoints',true);
             wkstV = [wkst(m).Vertices,repmat(z_soll(m),wkst(m).numsides,1)];
-            pltSim.toolMvmt(wkstV,wzV);
+%             pltSim.toolMvmt(wkstV,wzV);
         end
+        pltSim.toolMvmt(wkstV,wzV);
         % Ergebnisse wegschreiben
         Bsol(1,:,n) = B;
         zSolInd(n) = m;

--- a/ptCloud2video.m
+++ b/ptCloud2video.m
@@ -1,6 +1,6 @@
 % create a struct containing al setup parameters
-rd.recfull = true;
-rd.outputv = false;
+rd.recfull = false;
+rd.outputv = true;
 rd.rotation = 'full';
 rd.horizMode = 'spline';
 rd.framerate = 90;
@@ -25,8 +25,8 @@ else
 end
 
 if rd.outputv
-    drawnow();
-    M = repmat(getframe(figH),numel(part),1);  % grab a dummy frame and preallocate RAM with it
+    drawnow
+    M = repmat(getframe(figH),numel(rd.frames),1);  % grab a dummy frame and preallocate RAM with it
 end
 
 % define equation for camera azimuth movement
@@ -83,7 +83,7 @@ if rd.outputv
     end
     
     v = VideoWriter(io.ff);
-    v.FrameRate = framerate;
+    v.FrameRate = rd.framerate;
     
     open(v)
     writeVideo(v,M)         % Write the matrix of data M to the video file.

--- a/testing/offsetOddVerts.m
+++ b/testing/offsetOddVerts.m
@@ -1,0 +1,11 @@
+zRes = 50;
+nPt = 50;
+z = linspace(0,50,zRes);
+zind = 0:zRes;
+cver = circle(20,nPt,[0,0]);      % erzeugen der Vertices der Werkstück-Polygone
+orPgon = polyshape(cver','Simplify',false);              % erzeugen des Originalen Werkstückpolgons
+wkst = repmat(orPgon,zRes,1);
+oddind = logical(mod(zind,2));
+wkst(oddind) = wkst(oddind).rotate( rad2deg( pi/(nPt) ));
+vert = extractVert(wkst,z);
+pcshow(vert)


### PR DESCRIPTION
simulation:
- increase number of points vertically and horizontally
- rotate odd-numbered layers in workpiece by half an angle increment, to acchieve a more even surface
  - tried this procedure in a testing script
- move plotting of tool movement outside of the loop over tool points
plotSimulation
- add view to 3d cut and seek plot
- add x-axis limits to the tool movement plot
ptCloud video write script
- tried using, not really successful