### PR TITLE
Vertex classification

### DIFF
--- a/methods/vf1/vf1.m
+++ b/methods/vf1/vf1.m
@@ -33,20 +33,21 @@ A = 0;
 
 %% Simulations-Setup
 ptNm = numel(phi_WZ);
-ptID = 3;                             % select point for plotting
-zInt = [15 90];         % [zmin zmax]
-zRes = 1e3;             % diskrete Schritte in z-Richtung
-circRes = 1e3;          % anzahl punkte entlang dem Werkstückumfang
+ptID = 3;                                   % select point for plotting
+zInt = [60 90];                             % [zmin zmax]
+zRes = 5;                                   % [Ebenen/mm] Auflösung in z-Richtung
+nDisE = ceil(zRes * abs(diff(zInt)));    % Anzahl diskrete Ebenen in z-Richtung, nach oben gerundet, damit geforderte Auflösung auf jeden Fall eingehalten wird
+nDisC = ceil(pi * rWst * sqrt(3) * zRes);   % Anzahl Vertices entlang dem Werkstückumfangs (kreis), nach oben gerundet, ...
 iterAbbr = 1e-3;        % zulässiger Fehler bei der Iteration
 dB = 0.1*pi;            % schrittweite beim seeken
 logStr = {'no', 'yes'}; % logical string for log outputs
-StopCriterion = pi/3;
+StopCriterion = 2*pi;
 % preallocate variables
-z_soll = linspace(zInt(2),zInt(1),zRes);
-Bsol  = NaN(1,ptNm,zRes);   % Lösungsvektor
-iters = NaN(zRes,1);               % Vektor der notwendigen Iterationsschritte
-err   = NaN(zRes,1);               % vector of errors
-zSolInd = NaN(zRes,1);             % vektor of Indizies der simulierten z Werte
+z_soll = linspace(zInt(2),zInt(1),nDisE);
+Bsol  = NaN(1,ptNm,nDisE);   % Lösungsvektor
+iters = NaN(nDisE,1);               % Vektor der notwendigen Iterationsschritte
+err   = NaN(nDisE,1);               % vector of errors
+zSolInd = NaN(nDisE,1);             % vektor of Indizies der simulierten z Werte
 % init variables
 n = 1;                                  % absoluter zähler der simulierten Schritte
 B = 0;                                  % Startwert für B
@@ -57,12 +58,12 @@ engaged = false;                        % Werkzeug im Eingriff
 runSim = true;                          % soll simulation ausgeührt werden
 prevEng = false;                        % war Werkzeug beim vorherigen Iterationsschritt im Eingriff
 % werkstück polygons
-cver = circle(rWst,circRes,[0,0]);      % erzeugen der Vertices der Werkstück-Polygone
+cver = circle(rWst,nDisC,[0,0]);      % erzeugen der Vertices der Werkstück-Polygone
 orPgon = polyshape(cver','Simplify',false);              % erzeugen des Originalen Werkstückpolgons
-wkst = repmat(orPgon,zRes,1);
+wkst = repmat(orPgon,nDisE,1);
 % rotate the odd numbered polyshapes by half a rotational space
-oddind = logical(mod(1:zRes,2));
-wkst(oddind) = wkst(oddind).rotate( rad2deg( pi/(circRes) ));
+oddind = logical(mod(1:nDisE,2));
+wkst(oddind) = wkst(oddind).rotate( rad2deg( pi/(nDisC) ));
 clearvars oddind
 % werkzeug polygon
 [cWZ(1,:),cWZ(2,:)] = pol2cart(phi_WZ,r_WZ,h_WZ);  % kartesische werkzeug koordinaten

--- a/ptCloud2video.m
+++ b/ptCloud2video.m
@@ -1,6 +1,6 @@
 % create a struct containing al setup parameters
 rd.recfull = false;
-rd.outputv = true;
+rd.outputv = false;
 rd.rotation = 'full';
 rd.horizMode = 'spline';
 rd.framerate = 90;

--- a/testing/quickpcShow.m
+++ b/testing/quickpcShow.m
@@ -1,0 +1,6 @@
+cCL = [[0 0 1];...   blue: intersection
+       [1 1 1];...   white: workpiece
+       [1 0 1]];   % magenta: tool
+   
+
+pcshow(vert,cCL(sIDLuT+1,:));

--- a/testing/tiledTest.m
+++ b/testing/tiledTest.m
@@ -1,0 +1,20 @@
+[figH,axH] = getFigH(1,'WindowStyle','docked');
+set(0,'CurrentFigure',figH);
+tH = tiledlayout(figH,5,1);
+axH(1) = nexttile(tH,1,[3 1]);
+legend('hdfjs','hfdskjs')
+axH(2) = nexttile(tH,4);
+axH(3) = nexttile(tH,5);
+axSetup();
+
+x = linspace(0,2*pi);
+lH(1) = gobjects(1);
+
+lH(1) = line(axH(1),x,sin(x));
+
+lH(3) = line(axH(3),x,exp(x));
+lH(2) = line(axH(2),x,cos(x));
+
+lH(4) = line(axH(1),x,sin(2*x));
+
+lH(1).YData = sin(x+1);

--- a/testing/vertexClassifcation.m
+++ b/testing/vertexClassifcation.m
@@ -34,5 +34,9 @@ for cut = 1:3
     sIDHn = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sID),'Color','#77AC30');
     sIDLuT = sID;                         % look up table: klassifizierung für den nächsten Schritt speichern
     % nächsten Schnitt vorbereiten
-    poly2 = poly2.translate([0.25 -0.25]);
+    if cut < 2
+        poly2 = poly2.translate([0.25 -0.25]);
+    else
+        poly2 = poly2.translate([0 -0.25]);
+    end
 end

--- a/testing/vertexClassifcation.m
+++ b/testing/vertexClassifcation.m
@@ -10,7 +10,20 @@ axis(axH,'equal');
 axH(1).XLim = [-0.5 2];
 axH(1).YLim = axH(1).XLim;
 axSetup;
+p1args = {'FaceColor','#D95319','FaceAlpha',0.25,'EdgeColor','none'};
+p2args = {'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none'};
+poargs = {'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none'};
+toargs = {'Color','#A2142F','HorizontalAlignment','right'};
+tnargs = {'Color','#77AC30'};
 
+cID = {'i','w','t'};    % classification Identifiers
+% i:    intersection. Punkt ist Verschneidung von workpiece und tool
+% w:    workpiece. Punkt war ursprünglich Element der Werkstückwolke
+% t:    tool. Punkt war ursprünglich Element der Werkzeugwolke
+cCL = [[0 0.4470 0.7410];...        intersection
+       [0.4660 0.6740 0.1880];...   workpiece
+       [0.6350 0.0780 0.1840]];   % tool
+   
 % 1.Schnitt vorbereiten
 poly1 = polyshape([0 0 1 1],[1 0 0 1],'KeepCollinearPoints',true);
 sIDLuT = ones(4,1);                       % originale Vertex Klassi.: alle gehören Poly1
@@ -19,20 +32,20 @@ poly2 = translate(poly1,[0.25 0.75]);
 for cut = 1:3
     % ausgangszustand plotten
     v1 = poly1.Vertices';
-    patch(axH(2*cut-1),'XData',v1(1,:),'YData',v1(2,:),'FaceColor','#D95319','FaceAlpha',0.25,'EdgeColor','none');
+    patch(axH(2*cut-1),'XData',v1(1,:),'YData',v1(2,:),p1args{:});
     text(axH(2*cut-1),v1(1,:),v1(2,:),num2str((1:poly1.numsides)'));
     v2 = poly2.Vertices';
-    patch(axH(2*cut-1),'XData',v2(1,:),'YData',v2(2,:),'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none');
+    patch(axH(2*cut-1),'XData',v2(1,:),'YData',v2(2,:),p2args{:});
     % schneiden
     [poly1,sID,vID] = poly1.subtract(poly2);
     resMat = [poly1.Vertices,sID,vID];
     vo = poly1.Vertices';
     % geschnittener Zustand plotten
-    patch(axH(2*cut),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
-    sIDHo = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sID),'Color','#A2142F','HorizontalAlignment','right');          % ausgegebene Klassifizierung
-    sID(sID ==1) = sIDLuT(vID(sID == 1));	% manipulation der aktuellen klassifizierung
-    sIDHn = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sID),'Color','#77AC30');
-    sIDLuT = sID;                         % look up table: klassifizierung für den nächsten Schritt speichern
+    patch(axH(2*cut),'XData',vo(1,:),'YData',vo(2,:),poargs{:});
+    sIDHo = text(axH(2*cut),vo(1,:),vo(2,:),cID(sID+1),toargs{:});          % ausgabe der unveränderten klassifizierung
+    sID(sID ==1) = sIDLuT(vID(sID == 1));                                   % manipulation der aktuellen klassifizierung
+    sIDHn = text(axH(2*cut),vo(1,:),vo(2,:),cID(sID+1),tnargs{:});          % ausgabe der veränderten klassifizierung
+    sIDLuT = sID;                                                           % look up table: klassifizierung für den nächsten Schritt speichern
     % nächsten Schnitt vorbereiten
     if cut < 2
         poly2 = poly2.translate([0.25 -0.25]);

--- a/testing/vertexClassifcation.m
+++ b/testing/vertexClassifcation.m
@@ -13,7 +13,7 @@ axSetup;
 
 % 1.Schnitt vorbereiten
 poly1 = polyshape([0 0 1 1],[1 0 0 1],'KeepCollinearPoints',true);
-sIDo = ones(4,1);                       % originale Vertex Klassi.: alle gehören Poly1
+sIDLuT = ones(4,1);                       % originale Vertex Klassi.: alle gehören Poly1
 poly2 = translate(poly1,[0.25 0.75]);
 
 for cut = 1:3
@@ -30,10 +30,9 @@ for cut = 1:3
     % geschnittener Zustand plotten
     patch(axH(2*cut),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
     sIDHo = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sID),'Color','#A2142F','HorizontalAlignment','right');          % ausgegebene Klassifizierung
-    sIDoLuT = sIDo;                         % look up table: klassifizierung des letzten schrittes speichern
-    sIDo = sID;                             % kopieren der aktuellen klassifizierung
-    sIDo(sID ==1) = sIDoLuT(vID(sID == 1));	% manipulation der aktuellen klassifizierung
-    sIDHn = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sIDo),'Color','#77AC30');
+    sID(sID ==1) = sIDLuT(vID(sID == 1));	% manipulation der aktuellen klassifizierung
+    sIDHn = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sID),'Color','#77AC30');
+    sIDLuT = sID;                         % look up table: klassifizierung für den nächsten Schritt speichern
     % nächsten Schnitt vorbereiten
     poly2 = poly2.translate([0.25 -0.25]);
 end

--- a/testing/vertexClassifcation.m
+++ b/testing/vertexClassifcation.m
@@ -1,7 +1,8 @@
+clearvars; clf;
 [figH] = getFigH(1);
-tH = tiledlayout(figH,2,2);
+tH = tiledlayout(figH,3,2);
 axH = gobjects(4,1);
-for tl = 1:4
+for tl = 1:6
     axH(tl) = nexttile(tH,tl);
 end
 linkaxes(axH)
@@ -12,28 +13,27 @@ axSetup;
 
 % 1.Schnitt vorbereiten
 poly1 = polyshape([0 0 1 1],[1 0 0 1],'KeepCollinearPoints',true);
-v1 = poly1.Vertices';
-patch(axH(1),'XData',v1(1,:),'YData',v1(2,:),'FaceColor','#D95319','FaceAlpha',0.25,'EdgeColor','none');
-poly2 = translate(poly1,[0.5 0.5]);
-v2 = poly2.Vertices';
-patch(axH(1),'XData',v2(1,:),'YData',v2(2,:),'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none');
-% 1. schnitt
-[polyout,sID,vID] = poly1.subtract(poly2);
-resMat = [polyout.Vertices,sID,vID];
-vo = polyout.Vertices';
-patch(axH(2),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
-sIDH = text(axH(2),vo(1,:),vo(2,:),num2str(sID));
-% 2.Schnitt vorbereiten
-poly22 = poly2.translate([0.1 -0.25]);
-v22 = poly22.Vertices';
-patch(axH(3),'XData',v22(1,:),'YData',v22(2,:),'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none');
-patch(axH(3),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
-% 2. Schnitt
-[polyout2,sID2,vID2] = polyout.subtract(poly22);
-resMat2 = [polyout2.Vertices,sID2,vID2];
-vo2 = polyout2.Vertices';
-patch(axH(4),'XData',vo2(1,:),'YData',vo2(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
+sIDo = ones(4,1);                       % originale Vertex Klassi.: alle gehören Poly1
+poly2 = translate(poly1,[0.25 0.75]);
 
-sID2t(sID2 ==1) = sID(vID2(sID2 ==1));
-
-sIDH2 = text(axH(4),vo2(1,:),vo2(2,:),num2str(sID2t));
+for cut = 1:3
+    % ausgangszustand plotten
+    v1 = poly1.Vertices';
+    patch(axH(2*cut-1),'XData',v1(1,:),'YData',v1(2,:),'FaceColor','#D95319','FaceAlpha',0.25,'EdgeColor','none');
+    text(axH(2*cut-1),v1(1,:),v1(2,:),num2str((1:poly1.numsides)'));
+    v2 = poly2.Vertices';
+    patch(axH(2*cut-1),'XData',v2(1,:),'YData',v2(2,:),'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none');
+    % schneiden
+    [poly1,sID,vID] = poly1.subtract(poly2);
+    resMat = [poly1.Vertices,sID,vID];
+    vo = poly1.Vertices';
+    % geschnittener Zustand plotten
+    patch(axH(2*cut),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
+    sIDHo = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sID),'Color','#A2142F','HorizontalAlignment','right');          % ausgegebene Klassifizierung
+    sIDoLuT = sIDo;                         % look up table: klassifizierung des letzten schrittes speichern
+    sIDo = sID;                             % kopieren der aktuellen klassifizierung
+    sIDo(sID ==1) = sIDoLuT(vID(sID == 1));	% manipulation der aktuellen klassifizierung
+    sIDHn = text(axH(2*cut),vo(1,:),vo(2,:),num2str(sIDo),'Color','#77AC30');
+    % nächsten Schnitt vorbereiten
+    poly2 = poly2.translate([0.25 -0.25]);
+end

--- a/testing/vertexClassifcation.m
+++ b/testing/vertexClassifcation.m
@@ -1,0 +1,39 @@
+[figH] = getFigH(1);
+tH = tiledlayout(figH,2,2);
+axH = gobjects(4,1);
+for tl = 1:4
+    axH(tl) = nexttile(tH,tl);
+end
+linkaxes(axH)
+axis(axH,'equal');
+axH(1).XLim = [-0.5 2];
+axH(1).YLim = axH(1).XLim;
+axSetup;
+
+% 1.Schnitt vorbereiten
+poly1 = polyshape([0 0 1 1],[1 0 0 1],'KeepCollinearPoints',true);
+v1 = poly1.Vertices';
+patch(axH(1),'XData',v1(1,:),'YData',v1(2,:),'FaceColor','#D95319','FaceAlpha',0.25,'EdgeColor','none');
+poly2 = translate(poly1,[0.5 0.5]);
+v2 = poly2.Vertices';
+patch(axH(1),'XData',v2(1,:),'YData',v2(2,:),'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none');
+% 1. schnitt
+[polyout,sID,vID] = poly1.subtract(poly2);
+resMat = [polyout.Vertices,sID,vID];
+vo = polyout.Vertices';
+patch(axH(2),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
+sIDH = text(axH(2),vo(1,:),vo(2,:),num2str(sID));
+% 2.Schnitt vorbereiten
+poly22 = poly2.translate([0.1 -0.25]);
+v22 = poly22.Vertices';
+patch(axH(3),'XData',v22(1,:),'YData',v22(2,:),'FaceColor','#EDB120','FaceAlpha',0.25,'EdgeColor','none');
+patch(axH(3),'XData',vo(1,:),'YData',vo(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
+% 2. Schnitt
+[polyout2,sID2,vID2] = polyout.subtract(poly22);
+resMat2 = [polyout2.Vertices,sID2,vID2];
+vo2 = polyout2.Vertices';
+patch(axH(4),'XData',vo2(1,:),'YData',vo2(2,:),'FaceColor','#4DBEEE','FaceAlpha',0.25,'EdgeColor','none');
+
+sID2t(sID2 ==1) = sID(vID2(sID2 ==1));
+
+sIDH2 = text(axH(4),vo2(1,:),vo2(2,:),num2str(sID2t));


### PR DESCRIPTION
main Simulation script
- changed manner in which  resolutions are specified:
  - instead of the absolute number of discrete planes in workpiece, we define planes per unit
  - resolution along the workpiece circumference results in such a way, that triangles on workpiece surface are equilateral
- classification of vertices
  - keep record of origin of any vertices
  - the development of the algorithm in a separate script (vertexClassification.m)